### PR TITLE
Add Gemfile and ignore Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ yell.rb
 yeller.rb
 .DS_Store
 pkg/
+
+# Since this is a gem not an app, ignore the lock file
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+
+source "http://www.rubygems.org"
+
+gemspec


### PR DESCRIPTION
Just adds a Gemfile referencing the .gemspec and ignores the Gemfile.lock (since this is a gem).

Feel free to ignore if you didn't want to use bundler for some reason.
