### PR TITLE
allow advertising on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ yeller.rb
 pkg/
 tmp/
 *.bundle
-
+*.so
 # Since this is a gem not an app, ignore the lock file
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ advertiser.stop
 beacon = ScanBeacon::Beacon.new(
   ids: ["2F234454F4911BA9FFA6", 3],
   power: -20,
-  service_uuid: 0XFEAA,
+  service_uuid: 0xFEAA,
   beacon_type: :eddystone_uid
 )
 advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
@@ -86,4 +86,7 @@ advertiser.stop
 
 
 # Dependencies
-You must have a BLE112 device plugged in to a USB port, or a Mac, or a Linux machine w/ BlueZ installed.
+To scan for beacons, you must have a Linux machine with BlueZ installed, or a Mac, or a BLE112 device plugged in to a USB port (on Mac or Linux).
+
+To advertise as a beacon, you must have a Linux machine with BlueZ installed.
+

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Example:
 beacon = ScanBeacon::Beacon.new(
   ids: ["2F234454CF6D4A0FADF2F4911BA9FFA6", 11,11],
   power: -59,
-  mfg_id: "1801",
+  mfg_id: 0x0118,
   beacon_type: :altbeacon
 )
 advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
@@ -75,7 +75,7 @@ advertiser.stop
 beacon = ScanBeacon::Beacon.new(
   ids: ["2F234454F4911BA9FFA6", 3],
   power: -20,
-  service_uuid: "aafe",
+  service_uuid: 0XFEAA,
   beacon_type: :eddystone_uid
 )
 advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ require 'scan_beacon'
 scanner = ScanBeacon::CoreBluetoothScanner.new
 # to scan using a BLE112 device
 scanner = ScanBeacon::BLE112Scanner.new
-# to scan using BlueZ on Linux
+# to scan using BlueZ on Linux (make sure you have privileges)
 scanner = ScanBeacon::BlueZScanner.new
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,5 +54,24 @@ scanner.add_parser( ScanBeacon::BeaconParser.new(:mybeacon, "m:2-3=0000,i:4-19,i
 ...
 ```
 
+## Advertise as a beacon on Linux using BlueZ
+Example:
+``` ruby
+# altbeacon
+beacon = ScanBeacon::Beacon.new(ids: ["2F234454CF6D4A0FADF2F4911BA9FFA6", 11,11], power: -59, mfg_id: "1801", beacon_type: :altbeacon)
+advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
+advertiser.start
+...
+advertiser.stop
+
+# Eddystone UID
+beacon = ScanBeacon::Beacon.new(ids: ["2F234454F4911BA9FFA6", 3], power: -20, service_uuid: "aafe", beacon_type: :eddystone_uid)
+advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
+advertiser.start
+...
+advertiser.stop
+```
+
+
 # Dependencies
-You must have a BLE112 device plugged in to a USB port, or a Mac.
+You must have a BLE112 device plugged in to a USB port, or a Mac, or a Linux machine w/ BlueZ installed.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ require 'scan_beacon'
 scanner = ScanBeacon::CoreBluetoothScanner.new
 # to scan using a BLE112 device
 scanner = ScanBeacon::BLE112Scanner.new
+# to scan using BlueZ on Linux
+scanner = ScanBeacon::BlueZScanner.new
 ```
 
 ## Start a scan, yield beacons in a loop

--- a/README.md
+++ b/README.md
@@ -60,14 +60,24 @@ scanner.add_parser( ScanBeacon::BeaconParser.new(:mybeacon, "m:2-3=0000,i:4-19,i
 Example:
 ``` ruby
 # altbeacon
-beacon = ScanBeacon::Beacon.new(ids: ["2F234454CF6D4A0FADF2F4911BA9FFA6", 11,11], power: -59, mfg_id: "1801", beacon_type: :altbeacon)
+beacon = ScanBeacon::Beacon.new(
+  ids: ["2F234454CF6D4A0FADF2F4911BA9FFA6", 11,11],
+  power: -59,
+  mfg_id: "1801",
+  beacon_type: :altbeacon
+)
 advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
 advertiser.start
 ...
 advertiser.stop
 
 # Eddystone UID
-beacon = ScanBeacon::Beacon.new(ids: ["2F234454F4911BA9FFA6", 3], power: -20, service_uuid: "aafe", beacon_type: :eddystone_uid)
+beacon = ScanBeacon::Beacon.new(
+  ids: ["2F234454F4911BA9FFA6", 3],
+  power: -20,
+  service_uuid: "aafe",
+  beacon_type: :eddystone_uid
+)
 advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
 advertiser.start
 ...

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,7 @@ require "rake/extensiontask"
 Rake::ExtensionTask.new "core_bluetooth" do |ext|
   ext.lib_dir = "lib/scan_beacon"
 end
+
+Rake::ExtensionTask.new "bluez" do |ext|
+  ext.lib_dir = "lib/scan_beacon"
+end

--- a/ext/bluez/advertising.c
+++ b/ext/bluez/advertising.c
@@ -1,0 +1,125 @@
+#ifdef linux
+#include "ruby.h"
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+#pragma pack(1)
+
+
+#define FLAGS_NOT_CONNECTABLE 0x1A
+#define FLAGS_CONNECTABLE     0x18
+
+typedef struct {
+  uint8_t len;
+  struct {
+    uint8_t len;
+    uint8_t type;
+    uint8_t data;
+  } flags;
+  uint8_t ad_data[28];
+} Advertisement;
+
+Advertisement advertisement;
+int advertising;
+
+VALUE method_start_advertising();
+
+void init_advertisement()
+{
+  memset(&advertisement, 0, sizeof(advertisement));
+  advertisement.flags.len = 2;
+  advertisement.flags.type = 1;
+  advertisement.flags.data = FLAGS_NOT_CONNECTABLE;
+  advertising = 0;
+}
+
+VALUE method_set_connectable(VALUE self, VALUE connectable)
+{
+  if ( RTEST(connectable) )
+  {
+    advertisement.flags.data = FLAGS_CONNECTABLE;
+  } else {
+    advertisement.flags.data = FLAGS_NOT_CONNECTABLE;
+  };
+  if (advertising) {
+    method_start_advertising();
+  }
+  return connectable;
+}
+
+VALUE method_set_advertisement_bytes(VALUE self, VALUE bytes)
+{
+  uint8_t len = RSTRING_LEN(bytes);
+  if (len > 28) {
+    len = 28;
+  }
+  advertisement.len = len + advertisement.flags.len + 1; // + 1 is to account for the flags length field
+  memcpy(advertisement.ad_data, RSTRING_PTR(bytes), len);
+  if (advertising) {
+    method_start_advertising();
+  }
+  return bytes;
+}
+
+VALUE method_start_advertising()
+{
+  struct hci_request rq;
+  le_set_advertising_parameters_cp adv_params_cp;
+  uint8_t status;
+  
+  // open connection to the device
+  int device_id = hci_get_route(NULL);
+  int device_handle = hci_open_dev(device_id);
+
+  // set advertising data
+  memset(&rq, 0, sizeof(rq));
+  rq.ogf = OGF_LE_CTL;
+  rq.ocf = OCF_LE_SET_ADVERTISING_DATA;
+  rq.cparam = &advertisement;
+  rq.clen = sizeof(advertisement);
+  rq.rparam = &status;
+  rq.rlen = 1;
+  hci_send_req(device_handle, &rq, 1000);
+
+  // set advertising params
+  memset(&adv_params_cp, 0, sizeof(adv_params_cp));
+  uint16_t interval_100ms = htobs(0x00A0); // 0xA0 * 0.625ms = 100ms
+  adv_params_cp.min_interval = interval_100ms;
+  adv_params_cp.max_interval = interval_100ms;
+  adv_params_cp.advtype = 0x03; // non-connectable undirected advertising
+  adv_params_cp.chan_map = 0x07;// all 3 channels
+  memset(&rq, 0, sizeof(rq));
+  rq.ogf = OGF_LE_CTL;
+  rq.ocf = OCF_LE_SET_ADVERTISING_PARAMETERS;
+  rq.cparam = &adv_params_cp;
+  rq.clen = LE_SET_ADVERTISING_PARAMETERS_CP_SIZE;
+  rq.rparam = &status;
+  rq.rlen = 1;
+  hci_send_req(device_handle, &rq, 1000);
+
+  // turn on advertising
+  hci_le_set_advertise_enable(device_handle, 0x01, 1000);
+
+  // and close the connection
+  hci_close_dev(device_handle);
+  advertising = 1;
+  return Qnil;
+}
+
+VALUE method_stop_advertising()
+{
+  int device_id = hci_get_route(NULL);
+  int device_handle = hci_open_dev(device_id);
+  hci_le_set_advertise_enable(device_handle, 0x00, 1000);
+  hci_close_dev(device_handle);
+  advertising = 0;
+  return Qnil;
+}
+
+
+#endif // linux

--- a/ext/bluez/bluez.c
+++ b/ext/bluez/bluez.c
@@ -1,0 +1,182 @@
+#ifdef linux
+#include "ruby.h"
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+#pragma pack(1)
+
+VALUE bluez_module = Qnil;
+
+void Init_bluez();
+VALUE method_device_up();
+VALUE method_device_down();
+VALUE method_set_connectable(VALUE self, VALUE connectable);
+VALUE method_set_advertisement_bytes(VALUE self, VALUE bytes);
+VALUE method_start_advertising();
+VALUE method_stop_advertising();
+
+#define FLAGS_NOT_CONNECTABLE 0x1A
+#define FLAGS_CONNECTABLE     0x18
+
+typedef struct {
+  uint8_t len;
+  struct {
+    uint8_t len;
+    uint8_t type;
+    uint8_t data;
+  } flags;
+  uint8_t ad_len;
+  uint8_t ad_data[27];
+} Advertisement;
+
+Advertisement advertisement;
+int advertising;
+
+void Init_bluez()
+{
+  VALUE scan_beacon_module = rb_const_get(rb_cObject, rb_intern("ScanBeacon"));
+  bluez_module = rb_define_module_under(scan_beacon_module, "BlueZ");
+  rb_define_singleton_method(bluez_module, "device_up", method_device_up, 0);
+  rb_define_singleton_method(bluez_module, "device_down", method_device_down, 0);
+  rb_define_singleton_method(bluez_module, "start_advertising", method_start_advertising, 0);
+  rb_define_singleton_method(bluez_module, "stop_advertising", method_stop_advertising, 0);
+  rb_define_singleton_method(bluez_module, "advertisement_bytes=", method_set_advertisement_bytes, 1);
+  rb_define_singleton_method(bluez_module, "connectable=", method_set_connectable, 1);
+
+  // bring up the device, in case it's not already up
+  method_device_up();
+
+  // initialize the advertisement
+  memset(&advertisement, 0, sizeof(advertisement));
+  advertisement.flags.len = 2;
+  advertisement.flags.type = 1;
+  advertisement.flags.data = FLAGS_NOT_CONNECTABLE;
+  advertising = 0;
+}
+
+VALUE method_set_connectable(VALUE self, VALUE connectable)
+{
+  if ( RTEST(connectable) )
+  {
+    advertisement.flags.data = FLAGS_CONNECTABLE;
+  } else {
+    advertisement.flags.data = FLAGS_NOT_CONNECTABLE;
+  };
+  if (advertising) {
+    method_start_advertising();
+  }
+  return connectable;
+}
+
+VALUE method_set_advertisement_bytes(VALUE self, VALUE bytes)
+{
+  uint8_t len = RSTRING_LEN(bytes);
+  if (len > 27) {
+    len = 27;
+  }
+  advertisement.len = len + advertisement.flags.len + 2; // + 2 is to account for the flags length field and the ad length field
+  advertisement.ad_len = len;
+  memcpy(advertisement.ad_data, RSTRING_PTR(bytes), len);
+  if (advertising) {
+    method_start_advertising();
+  }
+  return bytes;
+}
+
+VALUE method_start_advertising()
+{
+  struct hci_request rq;
+  le_set_advertising_parameters_cp adv_params_cp;
+  uint8_t status;
+  
+  // open connection to the device
+  int device_id = hci_get_route(NULL);
+  int device_handle = hci_open_dev(device_id);
+
+  // set advertising data
+  memset(&rq, 0, sizeof(rq));
+  rq.ogf = OGF_LE_CTL;
+  rq.ocf = OCF_LE_SET_ADVERTISING_DATA;
+  rq.cparam = &advertisement;
+  rq.clen = sizeof(advertisement);
+  rq.rparam = &status;
+  rq.rlen = 1;
+  hci_send_req(device_handle, &rq, 1000);
+
+  // set advertising params
+  memset(&adv_params_cp, 0, sizeof(adv_params_cp));
+  uint16_t interval_100ms = htobs(0x00A0); // 0xA0 * 0.625ms = 100ms
+  adv_params_cp.min_interval = interval_100ms;
+  adv_params_cp.max_interval = interval_100ms;
+  adv_params_cp.advtype = 0x03; // non-connectable undirected advertising
+  adv_params_cp.chan_map = 0x07;// all 3 channels
+  memset(&rq, 0, sizeof(rq));
+  rq.ogf = OGF_LE_CTL;
+  rq.ocf = OCF_LE_SET_ADVERTISING_PARAMETERS;
+  rq.cparam = &adv_params_cp;
+  rq.clen = LE_SET_ADVERTISING_PARAMETERS_CP_SIZE;
+  rq.rparam = &status;
+  rq.rlen = 1;
+  hci_send_req(device_handle, &rq, 1000);
+
+  // turn on advertising
+  hci_le_set_advertise_enable(device_handle, 0x01, 1000);
+
+  // and close the connection
+  hci_close_dev(device_handle);
+  advertising = 1;
+  return Qnil;
+}
+
+VALUE method_stop_advertising()
+{
+  int device_id = hci_get_route(NULL);
+  int device_handle = hci_open_dev(device_id);
+  hci_le_set_advertise_enable(device_handle, 0x00, 1000);
+  hci_close_dev(device_handle);
+  advertising = 0;
+  return Qnil;
+}
+
+VALUE method_device_up()
+{
+  VALUE success;
+  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+  int hdev = 0;
+  /* Start HCI device */
+  if (ioctl(ctl, HCIDEVUP, hdev) < 0) {
+    if (errno == EALREADY) {
+      success = Qtrue;
+    } else {
+      fprintf(stderr, "Can't init device hci%d: %s (%d)\n", hdev, strerror(errno), errno);
+      success = Qfalse;
+    }
+  } else {
+    success = Qtrue;
+  }
+  close(ctl);
+  return success;
+}
+
+VALUE method_device_down()
+{
+  VALUE success;
+  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+  int hdev = 0;
+  /* Stop HCI device */
+  if (ioctl(ctl, HCIDEVDOWN, hdev) < 0) {
+    fprintf(stderr, "Can't down device hci%d: %s (%d)\n", hdev, strerror(errno), errno);
+    success = Qfalse;
+  } else {
+    success = Qtrue;
+  }
+  close(ctl);
+  return success;
+}
+
+#endif // linux

--- a/ext/bluez/bluez.c
+++ b/ext/bluez/bluez.c
@@ -8,257 +8,40 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
-#pragma pack(1)
 
 VALUE bluez_module = Qnil;
 
 void Init_bluez();
-VALUE method_device_up();
-VALUE method_device_down();
+VALUE method_device_up(VALUE self, VALUE device_id);
+VALUE method_device_down(VALUE self, VALUE device_id);
 VALUE method_set_connectable(VALUE self, VALUE connectable);
 VALUE method_set_advertisement_bytes(VALUE self, VALUE bytes);
 VALUE method_start_advertising();
 VALUE method_stop_advertising();
-VALUE method_scan();
-
-#define FLAGS_NOT_CONNECTABLE 0x1A
-#define FLAGS_CONNECTABLE     0x18
-
-typedef struct {
-  uint8_t len;
-  struct {
-    uint8_t len;
-    uint8_t type;
-    uint8_t data;
-  } flags;
-  uint8_t ad_len;
-  uint8_t ad_data[27];
-} Advertisement;
-
-Advertisement advertisement;
-int advertising;
+VALUE method_scan(int argc, VALUE *argv, VALUE klass);
+VALUE method_devices();
+void init_advertisement();
 
 void Init_bluez()
 {
   VALUE scan_beacon_module = rb_const_get(rb_cObject, rb_intern("ScanBeacon"));
   bluez_module = rb_define_module_under(scan_beacon_module, "BlueZ");
-  rb_define_singleton_method(bluez_module, "device_up", method_device_up, 0);
-  rb_define_singleton_method(bluez_module, "device_down", method_device_down, 0);
+  rb_define_singleton_method(bluez_module, "device_up", method_device_up, 1);
+  rb_define_singleton_method(bluez_module, "device_down", method_device_down, 1);
   rb_define_singleton_method(bluez_module, "start_advertising", method_start_advertising, 0);
   rb_define_singleton_method(bluez_module, "stop_advertising", method_stop_advertising, 0);
   rb_define_singleton_method(bluez_module, "advertisement_bytes=", method_set_advertisement_bytes, 1);
   rb_define_singleton_method(bluez_module, "connectable=", method_set_connectable, 1);
-  rb_define_singleton_method(bluez_module, "scan", method_scan, 0);
+  rb_define_singleton_method(bluez_module, "scan", method_scan, -1);
+  rb_define_singleton_method(bluez_module, "devices", method_devices, 0);
 
   // bring up the device, in case it's not already up
-  method_device_up();
+  int device_id = hci_get_route(NULL);
+  method_device_up(Qnil, INT2NUM(device_id));
 
   // initialize the advertisement
-  memset(&advertisement, 0, sizeof(advertisement));
-  advertisement.flags.len = 2;
-  advertisement.flags.type = 1;
-  advertisement.flags.data = FLAGS_NOT_CONNECTABLE;
-  advertising = 0;
+  init_advertisement();
 }
 
-VALUE method_set_connectable(VALUE self, VALUE connectable)
-{
-  if ( RTEST(connectable) )
-  {
-    advertisement.flags.data = FLAGS_CONNECTABLE;
-  } else {
-    advertisement.flags.data = FLAGS_NOT_CONNECTABLE;
-  };
-  if (advertising) {
-    method_start_advertising();
-  }
-  return connectable;
-}
-
-VALUE method_set_advertisement_bytes(VALUE self, VALUE bytes)
-{
-  uint8_t len = RSTRING_LEN(bytes);
-  if (len > 27) {
-    len = 27;
-  }
-  advertisement.len = len + advertisement.flags.len + 2; // + 2 is to account for the flags length field and the ad length field
-  advertisement.ad_len = len;
-  memcpy(advertisement.ad_data, RSTRING_PTR(bytes), len);
-  if (advertising) {
-    method_start_advertising();
-  }
-  return bytes;
-}
-
-VALUE method_start_advertising()
-{
-  struct hci_request rq;
-  le_set_advertising_parameters_cp adv_params_cp;
-  uint8_t status;
-  
-  // open connection to the device
-  int device_id = hci_get_route(NULL);
-  int device_handle = hci_open_dev(device_id);
-
-  // set advertising data
-  memset(&rq, 0, sizeof(rq));
-  rq.ogf = OGF_LE_CTL;
-  rq.ocf = OCF_LE_SET_ADVERTISING_DATA;
-  rq.cparam = &advertisement;
-  rq.clen = sizeof(advertisement);
-  rq.rparam = &status;
-  rq.rlen = 1;
-  hci_send_req(device_handle, &rq, 1000);
-
-  // set advertising params
-  memset(&adv_params_cp, 0, sizeof(adv_params_cp));
-  uint16_t interval_100ms = htobs(0x00A0); // 0xA0 * 0.625ms = 100ms
-  adv_params_cp.min_interval = interval_100ms;
-  adv_params_cp.max_interval = interval_100ms;
-  adv_params_cp.advtype = 0x03; // non-connectable undirected advertising
-  adv_params_cp.chan_map = 0x07;// all 3 channels
-  memset(&rq, 0, sizeof(rq));
-  rq.ogf = OGF_LE_CTL;
-  rq.ocf = OCF_LE_SET_ADVERTISING_PARAMETERS;
-  rq.cparam = &adv_params_cp;
-  rq.clen = LE_SET_ADVERTISING_PARAMETERS_CP_SIZE;
-  rq.rparam = &status;
-  rq.rlen = 1;
-  hci_send_req(device_handle, &rq, 1000);
-
-  // turn on advertising
-  hci_le_set_advertise_enable(device_handle, 0x01, 1000);
-
-  // and close the connection
-  hci_close_dev(device_handle);
-  advertising = 1;
-  return Qnil;
-}
-
-VALUE method_stop_advertising()
-{
-  int device_id = hci_get_route(NULL);
-  int device_handle = hci_open_dev(device_id);
-  hci_le_set_advertise_enable(device_handle, 0x00, 1000);
-  hci_close_dev(device_handle);
-  advertising = 0;
-  return Qnil;
-}
-
-VALUE method_device_up()
-{
-  VALUE success;
-  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
-  int hdev = 0;
-  /* Start HCI device */
-  if (ioctl(ctl, HCIDEVUP, hdev) < 0) {
-    if (errno == EALREADY) {
-      success = Qtrue;
-    } else {
-      fprintf(stderr, "Can't init device hci%d: %s (%d)\n", hdev, strerror(errno), errno);
-      success = Qfalse;
-    }
-  } else {
-    success = Qtrue;
-  }
-  close(ctl);
-  return success;
-}
-
-VALUE method_device_down()
-{
-  VALUE success;
-  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
-  int hdev = 0;
-  /* Stop HCI device */
-  if (ioctl(ctl, HCIDEVDOWN, hdev) < 0) {
-    fprintf(stderr, "Can't down device hci%d: %s (%d)\n", hdev, strerror(errno), errno);
-    success = Qfalse;
-  } else {
-    success = Qtrue;
-  }
-  close(ctl);
-  return success;
-}
-
-
-VALUE method_scan()
-{
-  int device_id = hci_get_route(NULL);
-  int device_handle = hci_open_dev(device_id);
-  uint8_t scan_type = 0x01; //passive
-  uint8_t own_type = 0x00; // I think this specifies not to use a random MAC
-  uint8_t filter_dups = 0x00;
-  uint8_t filter_policy = 0x00; // ?
-  uint16_t interval = htobs(0x010);
-  uint16_t window = htobs(0x010);
-  hci_le_set_scan_parameters(device_handle, scan_type, interval, window, own_type, filter_policy, 1000);
-  hci_le_set_scan_enable(device_handle, 0x01, 0x00, 1000);
-
-  unsigned char buf[HCI_MAX_EVENT_SIZE], *ptr;
-  struct hci_filter new_filter, old_filter;
-  socklen_t olen;
-  int len;
-
-  olen = sizeof(old_filter);
-  if (getsockopt(device_handle, SOL_HCI, HCI_FILTER, &old_filter, &olen) < 0) {
-    printf("Could not get socket options\n");
-    return -1;
-  }
-
-  hci_filter_clear(&new_filter);
-  hci_filter_set_ptype(HCI_EVENT_PKT, &new_filter);
-  hci_filter_set_event(EVT_LE_META_EVENT, &new_filter);
-
-  if (setsockopt(device_handle, SOL_HCI, HCI_FILTER, &new_filter, sizeof(new_filter)) < 0) {
-    printf("Could not set socket options\n");
-    return -1;
-  }
-
-  int keep_scanning = 1;
-  while (keep_scanning) {
-    evt_le_meta_event *meta;
-    le_advertising_info *info;
-    char addr[18];
-
-    while ((len = read(device_handle, buf, sizeof(buf))) < 0) {
-      if (errno == EAGAIN || errno == EINTR) {
-        continue;
-      }
-      keep_scanning = 0;
-      break;
-    }
-
-    if (len > 0) {
-      ptr = buf + (1 + HCI_EVENT_HDR_SIZE);
-      len -= (1 + HCI_EVENT_HDR_SIZE);
-      meta = (void *) ptr;
-      // check if this event is an  advertisement
-      if (meta->subevent != EVT_LE_ADVERTISING_REPORT) {
-        break;
-      }
-      // parse out the ad data, the mac, and the rssi
-      info = (le_advertising_info *) (meta->data + 1);
-      int8_t rssi = (int8_t)info->data[info->length];
-      VALUE ad_data = rb_str_new(info->data, info->length);
-      ba2str(&info->bdaddr, addr);
-      VALUE rb_addr = rb_str_new(addr, strlen(addr));
-      VALUE rb_ary = rb_ary_new();
-      rb_ary_push(rb_ary, rb_addr);
-      rb_ary_push(rb_ary, ad_data);
-      rb_ary_push(rb_ary, INT2NUM(rssi));
-      // ... and yield it to ruby
-      keep_scanning = rb_yield(rb_ary) != Qfalse;
-    }
-  }
-
-  // put back the old filter
-  setsockopt(device_handle, SOL_HCI, HCI_FILTER, &old_filter, sizeof(old_filter));
-
-  // stop scanning
-  hci_le_set_scan_enable(device_handle, 0x00, 0x00, 1000);
-  hci_close_dev(device_handle);
-  return Qnil;
-}
 
 #endif // linux

--- a/ext/bluez/bluez.c
+++ b/ext/bluez/bluez.c
@@ -35,10 +35,6 @@ void Init_bluez()
   rb_define_singleton_method(bluez_module, "scan", method_scan, -1);
   rb_define_singleton_method(bluez_module, "devices", method_devices, 0);
 
-  // bring up the device, in case it's not already up
-  int device_id = hci_get_route(NULL);
-  method_device_up(Qnil, INT2NUM(device_id));
-
   // initialize the advertisement
   init_advertisement();
 }

--- a/ext/bluez/devices.c
+++ b/ext/bluez/devices.c
@@ -1,0 +1,101 @@
+#ifdef linux
+#include "ruby.h"
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+
+#include "utils.h"
+
+VALUE method_device_up(VALUE self, VALUE device_id)
+{
+  VALUE success;
+  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+  int hdev = NUM2INT(device_id);
+  /* Start HCI device */
+  if (ioctl(ctl, HCIDEVUP, hdev) < 0) {
+    if (errno == EALREADY) {
+      success = Qtrue;
+    } else {
+      rb_sys_fail("Can't init device");
+      success = Qfalse;
+    }
+  } else {
+    success = Qtrue;
+  }
+  close(ctl);
+  return success;
+}
+
+VALUE method_device_down(VALUE self, VALUE device_id)
+{
+  VALUE success;
+  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+  int hdev = NUM2INT(device_id);
+  /* Stop HCI device */
+  if (ioctl(ctl, HCIDEVDOWN, hdev) < 0) {
+    rb_sys_fail("Can't init device");
+    success = Qfalse;
+  } else {
+    success = Qtrue;
+  }
+  close(ctl);
+  return success;
+}
+
+VALUE di_to_hash(struct hci_dev_info *di)
+{
+  VALUE hash = rb_hash_new();
+  rb_hash_aset(hash, ID2SYM(rb_intern("device_id")), INT2FIX(di->dev_id));
+  rb_hash_aset(hash, ID2SYM(rb_intern("name")), rb_str_new2(di->name));
+  rb_hash_aset(hash, ID2SYM(rb_intern("addr")), ba2value(&di->bdaddr));
+  if (hci_test_bit(HCI_UP, &di->flags)) {
+    rb_hash_aset(hash, ID2SYM(rb_intern("up")), Qtrue);
+  } else {
+    rb_hash_aset(hash, ID2SYM(rb_intern("up")), Qfalse);
+  }
+  return hash;
+}
+
+VALUE method_devices()
+{
+  struct hci_dev_list_req *dl;
+  struct hci_dev_req *dr;
+  struct hci_dev_info di;
+  int i;
+
+  if (!(dl = malloc(HCI_MAX_DEV * sizeof(struct hci_dev_req) + sizeof(uint16_t)))) {
+    rb_raise(rb_eException, "Can't allocate memory");    
+    return Qnil;
+  }
+  dl->dev_num = HCI_MAX_DEV;
+  dr = dl->dev_req;
+
+  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+  if (ioctl(ctl, HCIGETDEVLIST, (void *) dl) < 0) {
+    rb_raise(rb_eException, "Can't get device list");    
+    return Qnil;
+  }
+
+  VALUE devices = rb_ary_new();
+
+  for (i = 0; i< dl->dev_num; i++) {
+    di.dev_id = (dr+i)->dev_id;
+    if (ioctl(ctl, HCIGETDEVINFO, (void *) &di) < 0)
+      continue;
+    if (hci_test_bit(HCI_RAW, &di.flags) &&
+        !bacmp(&di.bdaddr, BDADDR_ANY)) {
+      int dd = hci_open_dev(di.dev_id);
+      hci_read_bd_addr(dd, &di.bdaddr, 1000);
+      hci_close_dev(dd);
+    }
+    rb_ary_push(devices, di_to_hash(&di));
+  }
+  return devices;
+}
+
+#endif // linux

--- a/ext/bluez/extconf.rb
+++ b/ext/bluez/extconf.rb
@@ -2,7 +2,7 @@
 require 'mkmf'
 
 # Give it a name
-extension_name = 'bluez'
+extension_name = 'scan_beacon/bluez'
 
 # The destination
 dir_config(extension_name)

--- a/ext/bluez/extconf.rb
+++ b/ext/bluez/extconf.rb
@@ -1,0 +1,12 @@
+# Loads mkmf which is used to make makefiles for Ruby extensions
+require 'mkmf'
+
+# Give it a name
+extension_name = 'bluez'
+
+# The destination
+dir_config(extension_name)
+
+abort 'could not find bluetooth library (libbluetooth-dev)' unless have_library("bluetooth")
+
+create_makefile(extension_name)

--- a/ext/bluez/extconf.rb
+++ b/ext/bluez/extconf.rb
@@ -7,6 +7,8 @@ extension_name = 'bluez'
 # The destination
 dir_config(extension_name)
 
-abort 'could not find bluetooth library (libbluetooth-dev)' unless have_library("bluetooth")
+if RUBY_PLATFORM =~ /linux/
+  abort 'could not find bluetooth library (libbluetooth-dev)' unless have_library("bluetooth")
+end
 
 create_makefile(extension_name)

--- a/ext/bluez/scanning.c
+++ b/ext/bluez/scanning.c
@@ -1,0 +1,127 @@
+#ifdef linux
+#include "ruby.h"
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+
+#include "utils.h"
+
+VALUE method_scan();
+
+
+VALUE stop_scan(VALUE device_id);
+VALUE perform_scan(VALUE device_id);
+
+struct hci_filter stored_filters[10];
+int device_handles[10];
+
+VALUE method_scan(int argc, VALUE *argv, VALUE klass)
+{
+  VALUE rb_device_id;
+  int device_id;
+  int device_handle;
+  uint8_t scan_type = 0x01; //passive
+  uint8_t own_type = 0x00; // I think this specifies not to use a random MAC
+  uint8_t filter_dups = 0x00;
+  uint8_t filter_policy = 0x00; // ?
+  uint16_t interval = htobs(0x0005);
+  uint16_t window = htobs(0x0005);
+
+  struct hci_filter new_filter;
+
+  // which device was specified?
+  rb_scan_args(argc, argv, "01", &rb_device_id);
+  if (rb_device_id == Qnil) {
+    device_id = hci_get_route(NULL);
+  } else {
+    device_id = NUM2INT(rb_device_id);
+  }
+  // open the device
+  if ( (device_handle = hci_open_dev(device_id)) < 0) {
+    rb_raise(rb_eException, "Could not open device");
+  }
+  device_handles[device_id] = device_handle;
+ 
+  // save the old filter so we can restore it later
+  int filter_size = sizeof(stored_filters[0]); 
+  if (getsockopt(device_handle, SOL_HCI, HCI_FILTER, &stored_filters[device_id], &filter_size) < 0) {
+    rb_raise(rb_eException, "Could not get socket options");
+  }
+
+  // new filter to only look for event packets
+  hci_filter_clear(&new_filter);
+  hci_filter_set_ptype(HCI_EVENT_PKT, &new_filter);
+  hci_filter_set_event(EVT_LE_META_EVENT, &new_filter);
+  if (setsockopt(device_handle, SOL_HCI, HCI_FILTER, &new_filter, sizeof(new_filter)) < 0) {
+    rb_raise(rb_eException, "Could not set socket options");
+  }
+
+  // set the params
+  hci_le_set_scan_parameters(device_handle, scan_type, interval, window, own_type, filter_policy, 1000);
+  hci_le_set_scan_enable(device_handle, 0x01, filter_dups, 1000);
+
+  // perform the scan and make sure device gets put back into a proper state
+  // even in the case of being interrupted by a ruby exception
+  rb_ensure(perform_scan, INT2FIX(device_id), stop_scan, INT2FIX(device_id));
+  return Qnil;
+}
+
+VALUE perform_scan(VALUE device_id_in)
+{
+  int device_id = FIX2INT(device_id_in);
+  int device_handle = device_handles[device_id];
+  unsigned char buf[HCI_MAX_EVENT_SIZE], *ptr;
+  int len;
+  int keep_scanning = 1;
+  while (keep_scanning) {
+    evt_le_meta_event *meta;
+    le_advertising_info *info;
+
+    // keep trying to read until we get something
+    while ((len = read(device_handle, buf, sizeof(buf))) < 0) {
+      if (errno == EAGAIN || errno == EINTR) {
+        continue;
+      }
+      keep_scanning = 0;
+      break;
+    }
+
+    if (len > 0) {
+      ptr = buf + (1 + HCI_EVENT_HDR_SIZE);
+      len -= (1 + HCI_EVENT_HDR_SIZE);
+      meta = (void *) ptr;
+      // check if this event is an  advertisement
+      if (meta->subevent != EVT_LE_ADVERTISING_REPORT) {
+        continue;
+      }
+      // parse out the ad data, the mac, and the rssi
+      info = (le_advertising_info *) (meta->data + 1);
+      VALUE rssi = INT2FIX( (int8_t)info->data[info->length] );
+      VALUE ad_data = rb_str_new(info->data, info->length);
+      VALUE addr = ba2value(&info->bdaddr);
+      keep_scanning = rb_yield_values(3, addr, ad_data, rssi) != Qfalse;
+    }
+  }
+  return Qnil;
+}
+
+VALUE stop_scan(VALUE device_id_in)
+{
+  int device_id = FIX2INT(device_id_in);
+  int device_handle = device_handles[device_id];
+
+  // put back the old filter
+  setsockopt(device_handle, SOL_HCI, HCI_FILTER, &stored_filters[device_id], sizeof(stored_filters[0]));
+
+  // stop scanning
+  hci_le_set_scan_enable(device_handle, 0x00, 0x00, 1000);
+  hci_close_dev(device_handle);
+  return Qnil;
+}
+
+#endif // linux

--- a/ext/bluez/utils.c
+++ b/ext/bluez/utils.c
@@ -1,0 +1,21 @@
+#ifdef linux
+#include "ruby.h"
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
+
+#include "utils.h"
+
+VALUE ba2value(bdaddr_t *bdaddr)
+{
+  char addr[18];
+  ba2str(bdaddr, addr);
+  return rb_str_new2(addr);
+}
+
+#endif // linux

--- a/ext/bluez/utils.h
+++ b/ext/bluez/utils.h
@@ -1,0 +1,2 @@
+
+VALUE ba2value(bdaddr_t *bdaddr);

--- a/ext/core_bluetooth/extconf.rb
+++ b/ext/core_bluetooth/extconf.rb
@@ -2,7 +2,7 @@
 require 'mkmf'
 
 # Give it a name
-extension_name = 'core_bluetooth'
+extension_name = 'scan_beacon/core_bluetooth'
 
 # The destination
 dir_config(extension_name)

--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -4,9 +4,12 @@ require "scan_beacon/beacon_parser"
 require "scan_beacon/generic_scanner"
 require "scan_beacon/ble112_device"
 require "scan_beacon/ble112_scanner"
-if RUBY_PLATFORM =~ /darwin/
+case RUBY_PLATFORM
+when /darwin/
   require "scan_beacon/core_bluetooth"
   require "scan_beacon/core_bluetooth_scanner"
+when /linux/
+  require "scan_beacon/bluez"
 end
 
 module ScanBeacon

--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -11,6 +11,7 @@ when /darwin/
 when /linux/
   require "scan_beacon/bluez"
   require "scan_beacon/bluez_scanner"
+  require "scan_beacon/bluez_advertiser"
 end
 
 module ScanBeacon

--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -10,6 +10,7 @@ when /darwin/
   require "scan_beacon/core_bluetooth_scanner"
 when /linux/
   require "scan_beacon/bluez"
+  require "scan_beacon/bluez_scanner"
 end
 
 module ScanBeacon

--- a/lib/scan_beacon/beacon.rb
+++ b/lib/scan_beacon/beacon.rb
@@ -3,11 +3,14 @@ require 'set'
 module ScanBeacon
   class Beacon
 
-    attr_accessor :mac, :ids, :power, :beacon_types
+    attr_accessor :mac, :ids, :power, :beacon_types, :data, :mfg_id, :service_uuid
 
     def initialize(opts={})
-      @ids = opts[:ids]
+      @ids = opts[:ids] || []
+      @data = opts[:data] || []
       @power = opts[:power]
+      @mfg_id = opts[:mfg_id]
+      @service_uuid = opts[:service_uuid]
       @beacon_types = Set.new [opts[:beacon_type]]
       @rssis = []
     end

--- a/lib/scan_beacon/beacon_parser.rb
+++ b/lib/scan_beacon/beacon_parser.rb
@@ -84,7 +84,7 @@ module ScanBeacon
     end
 
     def parse_mfg_or_service_id(data)
-      data[0..1].unpack('H*')[0]
+      data[0..1].unpack('S>')[0]
     end
 
     def parse_power(data)
@@ -105,9 +105,9 @@ module ScanBeacon
       end
       ad[@power[:start]..@power[:end]] = [beacon.power].pack('c')
       if @ad_type == AD_TYPE_SERVICE
-        "\x03\x03" + [beacon.service_uuid].pack("H*") + [length+1].pack('C') + BT_EIR_SERVICE_DATA + ad
+        "\x03\x03" + [beacon.service_uuid].pack("S<") + [length+1].pack('C') + BT_EIR_SERVICE_DATA + ad
       elsif @ad_type == AD_TYPE_MFG
-        ad[0..1] = [beacon.mfg_id].pack("H*")
+        ad[0..1] = [beacon.mfg_id].pack("S<")
         [length+1].pack('C') + [AD_TYPE_MFG].pack('C') +  ad
       end
     end

--- a/lib/scan_beacon/beacon_parser.rb
+++ b/lib/scan_beacon/beacon_parser.rb
@@ -1,6 +1,12 @@
 module ScanBeacon
   class BeaconParser
-    DEFAULT_LAYOUTS = {altbeacon: "m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25"}
+    DEFAULT_LAYOUTS = {
+      altbeacon: "m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25",
+      eddystone_uid: "s:0-1=aafe,m:2-2=00,p:3-3:-41,i:4-13,i:14-19;d:20-21"
+    }
+    AD_TYPE_MFG = 0xff
+    AD_TYPE_SERVICE = 0x03
+    BT_EIR_SERVICE_DATA = "\x16"
     attr_accessor :beacon_type
 
     def self.default_parsers
@@ -10,12 +16,21 @@ module ScanBeacon
     def initialize(beacon_type, layout)
       @beacon_type = beacon_type
       @layout = layout.split(",")
-      @matchers = @layout.find_all {|item| item[0] == "m"}.map {|matcher|
+      if layout.include?("s")
+        @ad_type = AD_TYPE_SERVICE
+      else
+        @ad_type = AD_TYPE_MFG
+      end
+      @matchers = @layout.find_all {|item| ["m", "s"].include? item[0]}.map {|matcher|
         _, range_start, range_end, expected = matcher.split(/:|=|-/)
         {start: range_start.to_i, end: range_end.to_i, expected: expected}
       }
       @ids = @layout.find_all {|item| item[0] == "i"}.map {|id|
         _, range_start, range_end = id.split(/:|-/)
+        {start: range_start.to_i, end: range_end.to_i}
+      }
+      @data_fields = @layout.find_all {|item| item[0] == "d"}.map {|field|
+        _, range_start, range_end = field.split(/:|-/)
         {start: range_start.to_i, end: range_end.to_i}
       }
       _, power_start, power_end = @layout.find {|item| item[0] == "p"}.split(/:|-/)
@@ -29,26 +44,87 @@ module ScanBeacon
       return true
     end
 
-    def parse(data)
-      return nil if !matches?(data)
-      Beacon.new(ids: parse_ids(data), power: parse_power(data), beacon_type: @beacon_type)
+    def parse(data, ad_type = AD_TYPE_MFG)
+      return nil if ad_type != @ad_type || !matches?(data)
+      if @ad_type == AD_TYPE_MFG
+        Beacon.new(ids: parse_ids(data), power: parse_power(data), beacon_type: @beacon_type,
+          data: parse_data_fields(data), mfg_id: parse_mfg_or_service_id(data))
+      else
+        Beacon.new(ids: parse_ids(data), power: parse_power(data), beacon_type: @beacon_type,
+          data: parse_data_fields(data), service_uuid: parse_mfg_or_service_id(data))
+      end
     end
 
     def parse_ids(data)
-      @ids.map {|id|
-        if id[:end] - id[:start] == 1
+      parse_elems(@ids, data)
+    end
+
+    def parse_data_fields(data)
+      parse_elems(@data_fields, data)
+    end
+
+    def parse_elems(elems, data)
+      elems.map {|elem|
+        elem_str = data[elem[:start]..elem[:end]]
+        elem_length = elem_str.size
+        case elem_length
+        when 1
+          elem_str.unpack('C')[0]
+        when 2 
           # two bytes, so treat it as a short (big endian)
-          data[id[:start]..id[:end]].unpack('S>')[0]
+          elem_str.unpack('S>')[0]
+        when 6
+          # 6 bytes, treat it is an eddystone instance id
+          ("\x00\x00"+elem_str).unpack('Q>')[0]
         else
           # not two bytes, so treat it as a hex string
-          data[id[:start]..id[:end]].unpack('H*').join
+          elem_str.unpack('H*').join
         end
       }
+    end
+
+    def parse_mfg_or_service_id(data)
+      data[0..1].unpack('H*')[0]
     end
 
     def parse_power(data)
       data[@power[:start]..@power[:end]].unpack('c')[0]
     end
+
+    def generate_ad(beacon)
+      length = [@matchers, @ids, @power, @data_fields].flatten.map {|elem| elem[:end] }.max + 1
+      ad = "\x00" * length
+      @matchers.each do |matcher|
+        ad[matcher[:start]..matcher[:end]] = [matcher[:expected]].pack("H*")
+      end
+      @ids.each_with_index do |id, index|
+        ad[id[:start]..id[:end]] = generate_field(id, beacon.ids[index])
+      end
+      @data_fields.each_with_index do |field, index|
+        ad[field[:start]..field[:end]] = generate_field(field, beacon.data[index]) unless beacon.data[index].nil?
+      end
+      ad[@power[:start]..@power[:end]] = [beacon.power].pack('c')
+      if @ad_type == AD_TYPE_SERVICE
+        "\x03\x03" + [beacon.service_uuid].pack("H*") + [length+1].pack('C') + BT_EIR_SERVICE_DATA + ad
+      elsif @ad_type == AD_TYPE_MFG
+        ad[0..1] = [beacon.mfg_id].pack("H*")
+        [length+1].pack('C') + [AD_TYPE_MFG].pack('C') +  ad
+      end
+    end
+
+    def generate_field(field, value)
+      field_length = field[:end] - field[:start] + 1
+      case field_length
+      when 1
+        [value].pack("c")
+      when 2
+        [value].pack("S>")
+      when 6
+        [value].pack("Q>")[2..-1]
+      else
+        [value].pack("H*")[0..field_length-1]
+      end
+    end 
 
     def inspect
       "<BeaconParser type=\"#{@beacon_type}\", layout=\"#{@layout.join(",")}\">"

--- a/lib/scan_beacon/ble112_scanner.rb
+++ b/lib/scan_beacon/ble112_scanner.rb
@@ -1,5 +1,3 @@
-require 'timeout'
-
 module ScanBeacon
   class BLE112Scanner < GenericScanner
 

--- a/lib/scan_beacon/bluez_advertiser.rb
+++ b/lib/scan_beacon/bluez_advertiser.rb
@@ -1,0 +1,45 @@
+module ScanBeacon
+  class BlueZAdvertiser
+ 
+    attr_accessor :beacon, :parser, :ad
+
+    def initialize(opts = {})
+      @device_id = opts[:device_id]
+      self.beacon = opts[:beacon]
+      self.parser = opts[:parser]
+      self.parser ||= BeaconParser.default_parsers.find {|parser| parser.beacon_type == beacon.beacon_types.first}
+    end
+
+    def beacon=(value)
+      @beacon = value
+      update_ad
+    end
+
+    def parser=(value)
+      @parser = value
+      update_ad
+    end
+
+    def ad=(value)
+      @ad = value
+      BlueZ.advertisement_bytes = @ad
+    end
+
+    def start
+      BlueZ.start_advertising
+    end
+
+    def stop
+      BlueZ.stop_advertising
+    end
+
+    def inspect
+      "<BlueZAdvertiser ad=#{@ad.inspect}>"
+    end
+
+    def update_ad
+      self.ad = @parser.generate_ad(@beacon) if @parser && @beacon
+    end
+
+  end
+end

--- a/lib/scan_beacon/bluez_scanner.rb
+++ b/lib/scan_beacon/bluez_scanner.rb
@@ -1,5 +1,3 @@
-require 'timeout'
-
 module ScanBeacon
   class BlueZScanner < GenericScanner
 

--- a/lib/scan_beacon/bluez_scanner.rb
+++ b/lib/scan_beacon/bluez_scanner.rb
@@ -1,0 +1,13 @@
+require 'timeout'
+
+module ScanBeacon
+  class BlueZScanner < GenericScanner
+
+    def each_advertisement
+      ScanBeacon::BlueZ.scan do |mac, ad_data, rssi|
+        yield(ad_data[5..-1], mac, rssi)
+      end
+    end
+
+  end
+end

--- a/lib/scan_beacon/bluez_scanner.rb
+++ b/lib/scan_beacon/bluez_scanner.rb
@@ -3,12 +3,15 @@ module ScanBeacon
 
     def initialize(opts = {})
       super
-      @device_id = opts[:device_id]
+      @device_id = opts[:device_id] || BlueZ.devices[0][:device_id]
+      BlueZ.device_up @device_id
     end
 
     def each_advertisement
       ScanBeacon::BlueZ.scan(@device_id) do |mac, ad_data, rssi|
-        if ad_data.size > 4
+        if ad_data.nil?
+          yield(nil)
+        elsif ad_data.size > 4
           ad_type = ad_data[4].unpack("C")[0]
           if ad_type == 0xff
             yield(ad_data[5..-1], mac, rssi, ad_type)

--- a/lib/scan_beacon/bluez_scanner.rb
+++ b/lib/scan_beacon/bluez_scanner.rb
@@ -1,9 +1,21 @@
 module ScanBeacon
   class BlueZScanner < GenericScanner
 
+    def initialize(opts = {})
+      super
+      @device_id = opts[:device_id]
+    end
+
     def each_advertisement
-      ScanBeacon::BlueZ.scan do |mac, ad_data, rssi|
-        yield(ad_data[5..-1], mac, rssi)
+      ScanBeacon::BlueZ.scan(@device_id) do |mac, ad_data, rssi|
+        if ad_data.size > 4
+          ad_type = ad_data[4].unpack("C")[0]
+          if ad_type == 0xff
+            yield(ad_data[5..-1], mac, rssi, ad_type)
+          else
+            yield(ad_data[9..-1], mac, rssi, ad_type)
+          end
+        end
       end
     end
 

--- a/lib/scan_beacon/core_bluetooth_scanner.rb
+++ b/lib/scan_beacon/core_bluetooth_scanner.rb
@@ -7,7 +7,12 @@ module ScanBeacon
         sleep 0.2
         advertisements = CoreBluetooth::new_adverts
         advertisements.each do |scan|
-          keep_scanning = false if yield(scan[:data], scan[:device], scan[:rssi]) == false
+          if scan[:service_uuid]
+            advert = scan[:service_uuid] + scan[:data]
+            keep_scanning = false if yield(advert, scan[:device], scan[:rssi], 0x03) == false
+          else
+            keep_scanning = false if yield(scan[:data], scan[:device], scan[:rssi], 0xff) == false
+          end
         end
         if advertisements.empty?
           keep_scanning = false if yield(nil, nil, nil) == false

--- a/lib/scan_beacon/generic_scanner.rb
+++ b/lib/scan_beacon/generic_scanner.rb
@@ -17,8 +17,8 @@ module ScanBeacon
       @beacons = []
       next_cycle = Time.now + @cycle_seconds
       keep_scanning = true
-      each_advertisement do |data, device, rssi|
-        detect_beacon(data, device, rssi) unless data.nil?
+      each_advertisement do |data, device, rssi, ad_type = BeaconParser::AD_TYPE_MFG|
+        detect_beacon(data, device, rssi, ad_type) unless data.nil?
 
         if Time.now > next_cycle
           if block_given?
@@ -37,9 +37,9 @@ module ScanBeacon
       raise NotImplementedError
     end
 
-    def detect_beacon(data, device, rssi)
+    def detect_beacon(data, device, rssi, ad_type)
       beacon = nil
-      if @parsers.detect {|parser| beacon = parser.parse(data) }
+      if @parsers.detect {|parser| beacon = parser.parse(data, ad_type) }
         beacon.mac = device
         add_beacon(beacon, rssi)
       end

--- a/lib/scan_beacon/version.rb
+++ b/lib/scan_beacon/version.rb
@@ -1,3 +1,3 @@
 module ScanBeacon
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/scan_beacon.gemspec
+++ b/scan_beacon.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.extensions    = %w[ext/core_bluetooth/extconf.rb]
+  spec.extensions    = %w[ext/core_bluetooth/extconf.rb ext/bluez/extconf.rb]
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.9"


### PR DESCRIPTION
Still a work in progress.

Here's how you'd use it:

On a linux box, you can do `rake compile` then `sudo bundle console` (for some reason using BlueZ requires sudo privileges).

Then, you can start an altbeacon advertisement with the following:
``` ruby
ScanBeacon::BlueZ.advertisement_bytes = "\xff\x18\x01\xbe\xac\xbe\xac\xbe\xac\x11\x11\x22\x22\x33\x33\x44\x44\x55\x55\x66\x66\x00\x09\x00\x08\xc5\x00"
ScanBeacon::BlueZ.start_advertising
```

To stop advertising:
``` ruby
ScanBeacon::BlueZ.stop_advertising
```