### PR TITLE
add a BeaconId class that allows accessing id fields as numbers or hex

### DIFF
--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -1,5 +1,6 @@
 require "scan_beacon/version"
 require "scan_beacon/beacon"
+require "scan_beacon/beacon_id"
 require "scan_beacon/beacon_parser"
 require "scan_beacon/generic_scanner"
 require "scan_beacon/ble112_device"

--- a/lib/scan_beacon/beacon.rb
+++ b/lib/scan_beacon/beacon.rb
@@ -32,15 +32,16 @@ module ScanBeacon
     end
 
     def uuid
-      "#{ids[0][0..7]}-#{ids[0][8..11]}-#{ids[0][12..15]}-#{ids[0][16..19]}-#{ids[0][20..-1]}".upcase
+      id0 = ids[0].to_s
+      "#{id0[0..7]}-#{id0[8..11]}-#{id0[12..15]}-#{id0[16..19]}-#{id0[20..-1]}".upcase
     end
 
     def major
-      ids[1]
+      ids[1].to_i
     end
 
     def minor
-      ids[2]
+      ids[2].to_i
     end
 
     def ad_count

--- a/lib/scan_beacon/beacon_id.rb
+++ b/lib/scan_beacon/beacon_id.rb
@@ -4,20 +4,24 @@ module ScanBeacon
     ENCODING = "ASCII-8BIT".freeze
     NULL_BYTE = "\x00".force_encoding(ENCODING).freeze
 
-    def initialize(bytes: nil, hex: nil, number: nil, length: nil)
-      self.set_data(bytes: bytes, hex: hex, number: number, length: length)
+    def initialize(opts = {})
+      self.set_data(opts)
     end
 
     def self.id_with_length(id, length)
       return id if id.is_a? BeaconId
       if id.is_a? String
         BeaconId.new hex: id, length: length
-      elsif id.is_a? Fixnum
+      elsif id.is_a? Integer
         BeaconId.new number: id, length: length
       end
     end
 
-    def set_data(bytes: nil, hex: nil, number: nil, length: nil)
+    def set_data(opts = {})
+      bytes = opts[:bytes]
+      hex = opts[:hex]
+      number = opts[:number]
+      length = opts[:length]
       if bytes
         @data = bytes.force_encoding(ENCODING)
       elsif hex

--- a/lib/scan_beacon/beacon_id.rb
+++ b/lib/scan_beacon/beacon_id.rb
@@ -1,0 +1,87 @@
+module ScanBeacon
+  class BeaconId
+    include Comparable
+    ENCODING = "ASCII-8BIT".freeze
+    NULL_BYTE = "\x00".force_encoding(ENCODING).freeze
+
+    def initialize(bytes: nil, hex: nil, number: nil, length: nil)
+      self.set_data(bytes: bytes, hex: hex, number: number, length: length)
+    end
+
+    def self.id_with_length(id, length)
+      return id if id.is_a? BeaconId
+      if id.is_a? String
+        BeaconId.new hex: id, length: length
+      elsif id.is_a? Fixnum
+        BeaconId.new number: id, length: length
+      end
+    end
+
+    def set_data(bytes: nil, hex: nil, number: nil, length: nil)
+      if bytes
+        @data = bytes.force_encoding(ENCODING)
+      elsif hex
+        # zero pad hex if needed
+        hex = "0"*(length*2-hex.size) + hex if length and hex.size < length*2
+        @data = [hex].pack("H*")
+      elsif number
+        raise ArgumentError.new("Must also give a field length when you give a number") if length.nil?
+        set_data(hex: number.to_s(16), length: length)
+      end
+    end
+
+    def value
+      if @data.size < 6
+        self.to_i
+      else
+        self.to_hex
+      end
+    end
+
+    def to_s
+      value.to_s
+    end
+
+    def inspect
+      "<BeaconId value=#{self.value.inspect}>"
+    end
+
+    def bytes
+      @data
+    end
+
+    def to_i
+      size = @data.size
+      case size
+      when 0
+        nil
+      when 1
+        @data.unpack("C")[0]
+      when 2
+        @data.unpack("S>")[0]
+      when 3
+        (NULL_BYTE + @data).unpack("L>")[0]
+      when 4
+        @data.unpack("L>")[0]
+      when 5,6,7
+        (NULL_BYTE*(8-size) + @data).unpack("Q>")[0]
+      when 8
+        @data.unpack("Q>")[0]
+      else
+        @data[-8..-1].unpack("Q>")[0]
+      end
+    end
+
+    def to_hex
+      @data.unpack("H*")[0]
+    end
+
+    def <=> (other)
+      if other.is_a? BeaconId
+        self.bytes <=> other.bytes
+      else
+        self.value <=> other
+      end
+    end
+  end
+end

--- a/lib/scan_beacon/beacon_parser.rb
+++ b/lib/scan_beacon/beacon_parser.rb
@@ -6,7 +6,7 @@ module ScanBeacon
     }
     AD_TYPE_MFG = 0xff
     AD_TYPE_SERVICE = 0x03
-    BT_EIR_SERVICE_DATA = "\x16"
+    BT_EIR_SERVICE_DATA = "\x16".force_encoding("ASCII-8BIT")
     attr_accessor :beacon_type
 
     def self.default_parsers
@@ -65,26 +65,13 @@ module ScanBeacon
     end
 
     def parse_data_fields(data)
-      parse_elems(@data_fields, data)
+      parse_elems(@data_fields, data).map(&:bytes)
     end
 
     def parse_elems(elems, data)
       elems.map {|elem|
         elem_str = data[elem[:start]..elem[:end]]
-        elem_length = elem_str.size
-        case elem_length
-        when 1
-          elem_str.unpack('C')[0]
-        when 2 
-          # two bytes, so treat it as a short (big endian)
-          elem_str.unpack('S>')[0]
-        when 6
-          # 6 bytes, treat it is an eddystone instance id
-          ("\x00\x00"+elem_str).unpack('Q>')[0]
-        else
-          # not two bytes, so treat it as a hex string
-          elem_str.unpack('H*').join
-        end
+        BeaconId.new(bytes: elem_str)
       }
     end
 
@@ -99,38 +86,30 @@ module ScanBeacon
 
     def generate_ad(beacon)
       length = [@matchers, @ids, @power, @data_fields].flatten.map {|elem| elem[:end] }.max + 1
-      ad = "\x00" * length
+      ad = ("\x00" * length).force_encoding("ASCII-8BIT")
       @matchers.each do |matcher|
         ad[matcher[:start]..matcher[:end]] = [matcher[:expected]].pack("H*")
       end
       @ids.each_with_index do |id, index|
-        ad[id[:start]..id[:end]] = generate_field(id, beacon.ids[index])
+        id_length = id[:end] - id[:start] + 1
+        id_bytes = BeaconId.id_with_length(beacon.ids[index], id_length).bytes
+        ad[id[:start]..id[:end]] = id_bytes
       end
       @data_fields.each_with_index do |field, index|
-        ad[field[:start]..field[:end]] = generate_field(field, beacon.data[index]) unless beacon.data[index].nil?
+        unless beacon.data[index].nil?
+          field_length = field[:end] - field[:start] + 1
+          field_bytes = BeaconId.id_with_length(beacon.data[index], field_length).bytes
+          ad[field[:start]..field[:end]] = field_bytes
+        end
       end
       ad[@power[:start]..@power[:end]] = [beacon.power].pack('c')
       if @ad_type == AD_TYPE_SERVICE
-        "\x03\x03" + [beacon.service_uuid].pack("S<") + [length+1].pack('C') + BT_EIR_SERVICE_DATA + ad
+        "\x03\x03".force_encoding("ASCII-8BIT") + [beacon.service_uuid].pack("S<") + [length+1].pack('C') + BT_EIR_SERVICE_DATA + ad
       elsif @ad_type == AD_TYPE_MFG
         ad[0..1] = [beacon.mfg_id].pack("S<")
         [length+1].pack('C') + [AD_TYPE_MFG].pack('C') +  ad
       end
     end
-
-    def generate_field(field, value)
-      field_length = field[:end] - field[:start] + 1
-      case field_length
-      when 1
-        [value].pack("c")
-      when 2
-        [value].pack("S>")
-      when 6
-        [value].pack("Q>")[2..-1]
-      else
-        [value].pack("H*")[0..field_length-1]
-      end
-    end 
 
     def inspect
       "<BeaconParser type=\"#{@beacon_type}\", layout=\"#{@layout.join(",")}\">"

--- a/spec/beacon_id_spec.rb
+++ b/spec/beacon_id_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'scan_beacon'
+
+module ScanBeacon
+  RSpec.describe BeaconId do
+
+    it "can be initialized with a hex string" do
+      id = BeaconId.new(hex: "aabbccdd")
+      expect( id.bytes ).to eq "\xaa\xbb\xcc\xdd".force_encoding("ASCII-8BIT")
+    end
+
+    it "can be initialized with a byte string" do
+      id = BeaconId.new(bytes: "\xaa\xbb\xcc\xdd")
+      expect( id.bytes ).to eq "\xaa\xbb\xcc\xdd".force_encoding("ASCII-8BIT")
+    end
+
+    it "can be initialized with a 8bit number" do
+      id = BeaconId.new(number: 200, length: 1)
+      expect( id.bytes ).to eq "\xc8".force_encoding("ASCII-8BIT")
+    end
+
+    it "can be initialized with a 16bit number" do
+      id = BeaconId.new(number: 10000, length: 2)
+      expect( id.bytes ).to eq "\x27\x10".force_encoding("ASCII-8BIT")
+    end
+
+    it "can be initialized with a 32bit number" do
+      id = BeaconId.new(number: 100000, length: 4)
+      expect( id.bytes ).to eq "\x00\x01\x86\xa0".force_encoding("ASCII-8BIT")
+    end
+
+    it "can be initialized with a 64bit number" do
+      id = BeaconId.new(number: 21474836470, length: 8)
+      expect( id.bytes ).to eq "\x00\x00\x00\x04\xFF\xFF\xFF\xF6".force_encoding("ASCII-8BIT")
+    end
+
+    it "can convert to a hex string" do
+      id = BeaconId.new(number: 10000, length: 2)
+      expect( id.to_hex ).to eq "2710"
+    end
+
+    it "can tell if it equals another BeaconId" do
+      id1 = BeaconId.new(number: 10000, length: 2)
+      id2 = BeaconId.new(number: 10000, length: 2)
+      expect( id1 ).to eq( id2 )
+    end
+    it "can tell if it does not equal another BeaconId" do
+      id1 = BeaconId.new(number: 10000, length: 2)
+      id2 = BeaconId.new(number: 20000, length: 2)
+      expect( id1 ).to_not eq( id2 )
+    end
+  end
+end

--- a/spec/beacon_parser_spec.rb
+++ b/spec/beacon_parser_spec.rb
@@ -7,13 +7,16 @@ RSpec.describe ScanBeacon::BeaconParser do
   let(:data) { payload[16..-1] }
   let(:altbeacon_layout) { "m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25" }
   let(:altbeacon_parser) { ScanBeacon::BeaconParser.new :altbeacon, altbeacon_layout }
+  let(:generated_ad) {
+    "\e\xFF\x18\x01\xBE\xAC/#DT\xCFmJ\x0F\xAD\xF2\xF4\x91\e\xA9\xFF\xA6\x00\v\x00\v\xC5\x00".force_encoding("ASCII-8BIT")
+  }
 
   it "can use an altbeacon layout to parse an altbeacon advertisement" do
     expect( altbeacon_parser.matches? data ).to be(true)
   end
 
   it "can parse altbeacon identifiers" do
-    expect( altbeacon_parser.parse_ids(data) ).to match_array(['2f234454cf6d4a0fadf2f4911ba9ffa6', 52931, 131])
+    expect( altbeacon_parser.parse_ids(data).map(&:value) ).to match_array(['2f234454cf6d4a0fadf2f4911ba9ffa6', 52931, 131])
   end
 
   it "can parse altbeacon power" do
@@ -25,5 +28,15 @@ RSpec.describe ScanBeacon::BeaconParser do
     parser = ScanBeacon::BeaconParser.new(:no_power, layout)
     power = parser.parse_power(payload)
     expect( power ).to be nil
+  end
+
+  it "can generate altbeacon advertisement bytes" do
+    beacon = ScanBeacon::Beacon.new(
+      ids: ["2F234454CF6D4A0FADF2F4911BA9FFA6", 11,11],
+      power: -59,
+      mfg_id: 0x0118,
+      beacon_type: :altbeacon
+    )
+    expect( altbeacon_parser.generate_ad(beacon) ).to eq( generated_ad )
   end
 end

--- a/spec/beacon_spec.rb
+++ b/spec/beacon_spec.rb
@@ -2,9 +2,28 @@ require 'spec_helper'
 require 'scan_beacon'
 
 RSpec.describe ScanBeacon::Beacon do
+  let(:beacon) {
+    beacon = ScanBeacon::Beacon.new(
+      ids: ["2F234454CF6D4A0FADF2F4911BA9FFA6",2,3],
+      power: -74,
+      beacon_type: :mybeacon
+    )
+  }
+
   it "counts advertisements" do
-    beacon = ScanBeacon::Beacon.new ids: [1,2,3], power: -74, beacon_type: :mybeacon
-    beacon.add_rssi -80
-    expect { beacon.add_rssi -82 }.to change{ beacon.ad_count}.by(1)
+    beacon.add_rssi(-80)
+    expect { beacon.add_rssi(-82) }.to change{ beacon.ad_count}.by(1)
+  end
+
+  it "can return the first id as a formatted uuid" do
+    expect( beacon.uuid ).to eq "2F234454-CF6D-4A0F-ADF2-F4911BA9FFA6"
+  end
+
+  it "can return the second id as major" do
+    expect( beacon.major ).to eq 2
+  end
+
+  it "can return the third id as minor" do
+    expect( beacon.minor ).to eq 3
   end
 end


### PR DESCRIPTION
This also allows `BeaconParser` to care less about the format of the various fields - it can delegate that to the `BeaconId` class.