### PR TITLE
BLE112 advertising & address rotation

### DIFF
--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -5,6 +5,7 @@ require "scan_beacon/beacon_parser"
 require "scan_beacon/generic_scanner"
 require "scan_beacon/ble112_device"
 require "scan_beacon/ble112_scanner"
+require "scan_beacon/ble112_advertiser"
 case RUBY_PLATFORM
 when /darwin/
   require "scan_beacon/core_bluetooth"

--- a/lib/scan_beacon/ble112_advertiser.rb
+++ b/lib/scan_beacon/ble112_advertiser.rb
@@ -1,0 +1,63 @@
+module ScanBeacon
+  class BLE112Advertiser
+
+    attr_accessor :beacon, :parser, :ad
+
+    def initialize(opts = {})
+      @device = BLE112Device.new opts[:port]
+      self.beacon = opts[:beacon]
+      self.parser = opts[:parser]
+      self.parser ||= BeaconParser.default_parsers.find {|parser| parser.beacon_type == beacon.beacon_types.first}
+      @advertising = false
+    end
+
+    def beacon=(value)
+      @beacon = value
+      update_ad
+    end
+
+    def parser=(value)
+      @parser = value
+      update_ad
+    end
+
+    def ad=(value)
+      @ad = value
+    end
+
+    def start(with_rotation = false)
+      @device.open do
+        @device.start_advertising(@ad, with_rotation)
+        @advertising = true
+      end
+    end
+
+    def stop
+      @device.open do
+        @device.stop_advertising
+        @advertising = false
+      end
+    end
+
+    def inspect
+      "<BLE112Advertiser ad=#{@ad.inspect}>"
+    end
+
+    def update_ad
+      self.ad = @parser.generate_ad(@beacon) if @parser && @beacon
+      self.start if @advertising
+    end
+
+    def rotate_addr
+      @device.open do
+        @device.rotate_addr
+      end
+    end
+
+    def rotate_addr_and_update_ad
+      self.update_ad
+      self.start(true)
+    end
+
+  end
+end


### PR DESCRIPTION
Update the BLE112Device class to support bluetooth address rotation (privacy mode)

I used the following code to test out the functionality

```
device = ScanBeacon::BLE112Device.new
device.open do |device|
  device.start_private
end

5.times do |i|
  sleep 1
  puts "changing: #{i}"
  device.open do |device|
    device.change_bluetooth_address
  end
end

device.open do |device|
  device.stop_adv
end
```