### PR TITLE
use BlueZ's LE_RANDOM_ADDRESS functionality for addr rotation

### DIFF
--- a/ext/bluez/bluez.c
+++ b/ext/bluez/bluez.c
@@ -16,7 +16,7 @@ VALUE method_device_up(VALUE self, VALUE device_id);
 VALUE method_device_down(VALUE self, VALUE device_id);
 //VALUE method_set_connectable(VALUE self, VALUE connectable);
 VALUE method_set_advertisement_bytes(VALUE self, VALUE rb_device_id, VALUE bytes);
-VALUE method_start_advertising(VALUE klass, VALUE rb_device_id);
+VALUE method_start_advertising(VALUE klass, VALUE rb_device_id, VALUE random_address);
 VALUE method_stop_advertising(VALUE klass, VALUE rb_device_id);
 VALUE method_scan(int argc, VALUE *argv, VALUE klass);
 VALUE method_devices();
@@ -29,7 +29,7 @@ void Init_bluez()
   bluez_module = rb_define_module_under(scan_beacon_module, "BlueZ");
   rb_define_singleton_method(bluez_module, "device_up", method_device_up, 1);
   rb_define_singleton_method(bluez_module, "device_down", method_device_down, 1);
-  rb_define_singleton_method(bluez_module, "start_advertising", method_start_advertising, 1);
+  rb_define_singleton_method(bluez_module, "start_advertising", method_start_advertising, 2);
   rb_define_singleton_method(bluez_module, "stop_advertising", method_stop_advertising, 1);
   rb_define_singleton_method(bluez_module, "set_advertisement_bytes", method_set_advertisement_bytes, 2);
   //rb_define_singleton_method(bluez_module, "connectable=", method_set_connectable, 1);

--- a/lib/scan_beacon/bluez_advertiser.rb
+++ b/lib/scan_beacon/bluez_advertiser.rb
@@ -29,7 +29,12 @@ module ScanBeacon
     end
 
     def start
-      BlueZ.start_advertising @device_id
+      BlueZ.start_advertising @device_id, nil
+    end
+
+    def start_with_random_addr
+      addr = random_addr
+      BlueZ.start_advertising @device_id, addr
     end
 
     def stop
@@ -45,19 +50,9 @@ module ScanBeacon
     end
 
     def rotate_addr_and_update_ad
-      self.addr = self.random_addr
       self.update_ad
-      self.start
-    end
-
-    def addr=(new_addr)
-      stop
-      @addr = new_addr
-      BlueZ.set_addr @device_id, @addr
-    end
-
-    def reset_addr
-      self.addr = @initial_addr
+      self.stop
+      self.start_with_random_addr
     end
 
     def random_addr


### PR DESCRIPTION
When you are setting the advertising parameters, BlueZ allows you to specify that you want to use a random address.  Then you can supply the random address you want to use.  This is better than actually setting your device's address for these reasons:
* you haven't lost your device's identity - it is still associated with it's original addr, it's just going to use a random addr to advertise for now.
* It is not device specific - this is a standard way to do this that all Bluetooth hardware is supposed to support.  Unlike the `bdaddr` tool's code, which is very device specific.