### PR TITLE
fix compiling issues on linux w/ Ruby 2.x

### DIFF
--- a/ext/bluez/addr_rotation.c
+++ b/ext/bluez/addr_rotation.c
@@ -23,7 +23,6 @@
  */
 
 #ifdef linux
-#include "ruby.h"
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
@@ -32,6 +31,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
+#include "ruby.h"
 
 #include "utils.h"
 

--- a/ext/bluez/advertising.c
+++ b/ext/bluez/advertising.c
@@ -1,5 +1,4 @@
 #ifdef linux
-#include "ruby.h"
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
@@ -8,6 +7,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
+#include "ruby.h"
 #pragma pack(1)
 
 
@@ -75,13 +75,15 @@ VALUE method_start_advertising(VALUE klass, VALUE rb_device_id, VALUE random_add
   struct hci_request rq;
   le_set_advertising_parameters_cp adv_params_cp;
   uint8_t status;
+  int device_handle;
+  uint16_t interval_100ms = htobs(0x00A0); // 0xA0 * 0.625ms = 100ms
 
   // open connection to the device
   int device_id = FIX2INT(rb_device_id);
   if (device_id < 0) {
     rb_raise(rb_eException, "Could not find device");
   }
-  int device_handle = hci_open_dev(device_id);
+  device_handle = hci_open_dev(device_id);
   if (device_handle < 0) {
     rb_raise(rb_eException, "Could not open device");
   }
@@ -97,7 +99,6 @@ VALUE method_start_advertising(VALUE klass, VALUE rb_device_id, VALUE random_add
 
   // set advertising params
   memset(&adv_params_cp, 0, sizeof(adv_params_cp));
-  uint16_t interval_100ms = htobs(0x00A0); // 0xA0 * 0.625ms = 100ms
   adv_params_cp.min_interval = interval_100ms;
   adv_params_cp.max_interval = interval_100ms;
   adv_params_cp.advtype = 0x03; // non-connectable undirected advertising

--- a/ext/bluez/bluez.c
+++ b/ext/bluez/bluez.c
@@ -1,5 +1,4 @@
 #ifdef linux
-#include "ruby.h"
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
@@ -8,6 +7,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
+#include "ruby.h"
 
 VALUE bluez_module = Qnil;
 

--- a/ext/bluez/devices.c
+++ b/ext/bluez/devices.c
@@ -1,5 +1,4 @@
 #ifdef linux
-#include "ruby.h"
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
@@ -8,6 +7,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
+#include "ruby.h"
 
 #include "utils.h"
 
@@ -67,6 +67,8 @@ VALUE method_devices()
   struct hci_dev_req *dr;
   struct hci_dev_info di;
   int i;
+  int ctl;
+  VALUE devices;
 
   if (!(dl = malloc(HCI_MAX_DEV * sizeof(struct hci_dev_req) + sizeof(uint16_t)))) {
     rb_raise(rb_eException, "Can't allocate memory");    
@@ -75,13 +77,13 @@ VALUE method_devices()
   dl->dev_num = HCI_MAX_DEV;
   dr = dl->dev_req;
 
-  int ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
+  ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
   if (ioctl(ctl, HCIGETDEVLIST, (void *) dl) < 0) {
     rb_raise(rb_eException, "Can't get device list");    
     return Qnil;
   }
 
-  VALUE devices = rb_ary_new();
+  devices = rb_ary_new();
 
   for (i = 0; i< dl->dev_num; i++) {
     di.dev_id = (dr+i)->dev_id;

--- a/ext/bluez/utils.c
+++ b/ext/bluez/utils.c
@@ -1,5 +1,4 @@
 #ifdef linux
-#include "ruby.h"
 #include <stdio.h>
 #include <errno.h>
 #include <unistd.h>
@@ -8,6 +7,7 @@
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
+#include "ruby.h"
 
 #include "utils.h"
 

--- a/ext/core_bluetooth/extconf.rb
+++ b/ext/core_bluetooth/extconf.rb
@@ -7,17 +7,19 @@ extension_name = 'scan_beacon/core_bluetooth'
 # The destination
 dir_config(extension_name)
 
-$DLDFLAGS << " -framework Foundation"
-$DLDFLAGS << " -framework CoreBluetooth"
-
-unless RUBY_PLATFORM =~ /darwin/
+if RUBY_PLATFORM =~ /darwin/
+  $DLDFLAGS << " -framework Foundation"
+  $DLDFLAGS << " -framework CoreBluetooth"
+else
   # don't compile the code on non-mac platforms because
   # CoreBluetooth wont be there, and we may not even have
   # the ability to compile ObjC code.
   COMPILE_C = "echo"
+  CONFIG['CC'] = "echo" # this is for Ruby 2.x mkmf
   # create a dummy .so file so RubyGems thinks everything
   # was successful.  We wont try to load it anyway.
   LINK_SO = "touch $@"
+  CONFIG['LDSHARED'] = "touch $@; echo" # for Ruby 2.x mkmf
 end
 
 create_makefile(extension_name)


### PR DESCRIPTION
Fix was mostly just moving the include for ruby.h to
after the include for bluetooth.h.  Otherwise bluetooth
would try to redefine some things and fail.  Other change
was moving all varaible declarations to the beginning of
blocks to avoid a warning.