### PR TITLE
add method to get mac addr from BLE112 device

### DIFF
--- a/lib/scan_beacon/ble112_scanner.rb
+++ b/lib/scan_beacon/ble112_scanner.rb
@@ -1,9 +1,12 @@
 module ScanBeacon
   class BLE112Scanner < GenericScanner
 
+    attr_reader :device_addr
+
     def initialize(opts = {})
       super
       @device = BLE112Device.new opts[:port]
+      @device_addr = @device.open{ @device.get_addr }
     end
 
     def each_advertisement

--- a/spec/ble112_scanner_spec.rb
+++ b/spec/ble112_scanner_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ScanBeacon::BLE112Scanner do
     allow_any_instance_of(ScanBeacon::BLE112Device).to receive(:start_scan)
     allow_any_instance_of(ScanBeacon::BLE112Device).to receive(:stop_scan)
     allow_any_instance_of(ScanBeacon::BLE112Device).to receive(:read).and_return(response)
+    allow_any_instance_of(ScanBeacon::BLE112Device).to receive(:get_addr).and_return("00:11:22:33:44:55")
   end
 
   it "can scan for altbeacons" do


### PR DESCRIPTION
This will allow us to distinguish between multiple BLE112 devices on a single computer