### PR TITLE
IOBluetooth advertising

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ScanBeacon gem
 
-A ruby gem that allows you to scan for beacon advertisements using CoreBluetooth (on Mac OS X) or a BlueGiga BLE112 device (on mac or linux)
+A ruby gem that allows you to scan for beacon advertisements using IOBluetooth (on Mac OS X) or a BlueGiga BLE112 device (on mac or linux)
 
 # Example Usage
 
@@ -13,12 +13,14 @@ gem install scan_beacon
 ## Create your scanner
 ``` ruby
 require 'scan_beacon'
+# to scan using the default device on mac or linux
+scanner = ScanBeacon::DefaultScanner.new
 # to scan using CoreBluetooth on a mac
 scanner = ScanBeacon::CoreBluetoothScanner.new
-# to scan using a BLE112 device
-scanner = ScanBeacon::BLE112Scanner.new
 # to scan using BlueZ on Linux (make sure you have privileges)
 scanner = ScanBeacon::BlueZScanner.new
+# to scan using a BLE112 device
+scanner = ScanBeacon::BLE112Scanner.new
 ```
 
 ## Start a scan, yield beacons in a loop
@@ -57,7 +59,7 @@ scanner.add_parser( ScanBeacon::BeaconParser.new(:mybeacon, "m:2-3=0000,i:4-19,i
 ...
 ```
 
-## Advertise as a beacon on Linux using BlueZ
+## Advertise as a beacon on Linux using BlueZ or a Mac using IOBluetooth
 Example:
 ``` ruby
 # altbeacon
@@ -67,7 +69,7 @@ beacon = ScanBeacon::Beacon.new(
   mfg_id: 0x0118,
   beacon_type: :altbeacon
 )
-advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
+advertiser = ScanBeacon::DefaultAdvertiser.new(beacon: beacon)
 advertiser.start
 ...
 advertiser.stop
@@ -79,7 +81,7 @@ beacon = ScanBeacon::Beacon.new(
   service_uuid: 0xFEAA,
   beacon_type: :eddystone_uid
 )
-advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
+advertiser = ScanBeacon::DefaultAdvertiser.new(beacon: beacon)
 advertiser.start
 ...
 advertiser.stop
@@ -89,7 +91,7 @@ beacon = ScanBeacon::EddystoneUrlBeacon.new(
   url: "http://radiusnetworks.com",
   power: -20,
 )
-advertiser = ScanBeacon::BlueZAdvertiser.new(beacon: beacon)
+advertiser = ScanBeacon::DefaultAdvertiser.new(beacon: beacon)
 advertiser.start
 ...
 advertiser.stop
@@ -97,6 +99,4 @@ advertiser.stop
 
 
 # Dependencies
-To scan for beacons, you must have a Linux machine with BlueZ installed, or a Mac, or a BLE112 device plugged in to a USB port (on Mac or Linux).
-
-To advertise as a beacon, you must have a Linux machine with BlueZ installed.
+To scan for beacons or advertise, you must have a Linux machine with BlueZ installed, or a Mac, or a BLE112 device plugged in to a USB port (on Mac or Linux).

--- a/ext/core_bluetooth/extconf.rb
+++ b/ext/core_bluetooth/extconf.rb
@@ -10,6 +10,7 @@ dir_config(extension_name)
 if RUBY_PLATFORM =~ /darwin/
   $DLDFLAGS << " -framework Foundation"
   $DLDFLAGS << " -framework CoreBluetooth"
+  $DLDFLAGS << " -framework IOBluetooth"
 else
   # don't compile the code on non-mac platforms because
   # CoreBluetooth wont be there, and we may not even have

--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -12,6 +12,7 @@ case RUBY_PLATFORM
 when /darwin/
   require "scan_beacon/core_bluetooth"
   require "scan_beacon/core_bluetooth_scanner"
+  require "scan_beacon/core_bluetooth_advertiser"
 when /linux/
   require "scan_beacon/bluez"
   require "scan_beacon/bluez_scanner"

--- a/lib/scan_beacon/bluez_advertiser.rb
+++ b/lib/scan_beacon/bluez_advertiser.rb
@@ -50,4 +50,5 @@ module ScanBeacon
     end
 
   end
+  DefaultAdvertiser = BlueZAdvertiser
 end

--- a/lib/scan_beacon/bluez_scanner.rb
+++ b/lib/scan_beacon/bluez_scanner.rb
@@ -23,4 +23,5 @@ module ScanBeacon
     end
 
   end
+  DefaultScanner = BlueZScanner
 end

--- a/lib/scan_beacon/core_bluetooth_advertiser.rb
+++ b/lib/scan_beacon/core_bluetooth_advertiser.rb
@@ -1,0 +1,26 @@
+module ScanBeacon
+  class CoreBluetoothAdvertiser < GenericIndividualAdvertiser
+
+    def initialize(opts = {})
+      super
+    end
+
+    def ad=(value)
+      @ad = value
+      CoreBluetooth.set_advertisement_data @ad
+    end
+
+    def start
+      CoreBluetooth.start_advertising
+    end
+
+    def stop
+      CoreBluetooth.stop_advertising
+    end
+
+    def inspect
+      "<CoreBluetoothAdvertiser ad=#{@ad.inspect}>"
+    end
+
+  end
+end

--- a/lib/scan_beacon/core_bluetooth_advertiser.rb
+++ b/lib/scan_beacon/core_bluetooth_advertiser.rb
@@ -23,4 +23,5 @@ module ScanBeacon
     end
 
   end
+  DefaultAdvertiser = CoreBluetoothAdvertiser
 end

--- a/lib/scan_beacon/core_bluetooth_scanner.rb
+++ b/lib/scan_beacon/core_bluetooth_scanner.rb
@@ -22,4 +22,5 @@ module ScanBeacon
     end
 
   end
+  DefaultScanner = CoreBluetoothScanner
 end


### PR DESCRIPTION
In addition to the ability to advertise on Mac OS w/ IOBluetooth, this also adds `DefaultScanner` and `DefaultAdvertiser` which are just aliases for the appropriate BlueZ or CoreBluetooth based scanners and advertisers.  This is a convenience for writing cross platform code.