### PR TITLE
Add beacon layout for Eddystone-EID

### DIFF
--- a/lib/scan_beacon/beacon_parser.rb
+++ b/lib/scan_beacon/beacon_parser.rb
@@ -5,6 +5,7 @@ module ScanBeacon
       eddystone_uid: "s:0-1=feaa,m:2-2=00,p:3-3:-41,i:4-13,i:14-19;d:20-21",
       eddystone_url: "s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-21v",
       eddystone_tlm: "s:0-1=feaa,m:2-2=20,d:3-3,d:4-5,d:6-7,d:8-11,d:12-15",
+      eddystone_eid: "s:0-1=feaa,m:2-2=30,p:3-3:-41,i:4-11",
     }
     AD_TYPE_MFG = 0xff
     AD_TYPE_SERVICE = 0x03


### PR DESCRIPTION
This will allow scanning for Eddystone™ EID beacons, but it does not include functionality to resolve these identifiers with a service (ie, Google's Proximity Beacon API).