### PR TITLE
Move gem defaults to main gem loader

### DIFF
--- a/lib/scan_beacon.rb
+++ b/lib/scan_beacon.rb
@@ -9,16 +9,20 @@ require "scan_beacon/ble112_scanner"
 require "scan_beacon/generic_advertiser"
 require "scan_beacon/generic_individual_advertiser"
 require "scan_beacon/ble112_advertiser"
-case RUBY_PLATFORM
-when /darwin/
-  require "scan_beacon/core_bluetooth"
-  require "scan_beacon/core_bluetooth_scanner"
-  require "scan_beacon/core_bluetooth_advertiser"
-when /linux/
-  require "scan_beacon/bluez"
-  require "scan_beacon/bluez_scanner"
-  require "scan_beacon/bluez_advertiser"
-end
 
 module ScanBeacon
+  case RUBY_PLATFORM
+  when /darwin/
+    require "scan_beacon/core_bluetooth"
+    require "scan_beacon/core_bluetooth_scanner"
+    require "scan_beacon/core_bluetooth_advertiser"
+    DefaultScanner = CoreBluetoothScanner
+    DefaultAdvertiser = CoreBluetoothAdvertiser
+  when /linux/
+    require "scan_beacon/bluez"
+    require "scan_beacon/bluez_scanner"
+    require "scan_beacon/bluez_advertiser"
+    DefaultScanner = BlueZScanner
+    DefaultAdvertiser = BlueZAdvertiser
+  end
 end

--- a/lib/scan_beacon/bluez_advertiser.rb
+++ b/lib/scan_beacon/bluez_advertiser.rb
@@ -49,5 +49,4 @@ module ScanBeacon
     end
 
   end
-  DefaultAdvertiser = BlueZAdvertiser
 end

--- a/lib/scan_beacon/bluez_scanner.rb
+++ b/lib/scan_beacon/bluez_scanner.rb
@@ -23,5 +23,4 @@ module ScanBeacon
     end
 
   end
-  DefaultScanner = BlueZScanner
 end

--- a/lib/scan_beacon/core_bluetooth_advertiser.rb
+++ b/lib/scan_beacon/core_bluetooth_advertiser.rb
@@ -29,5 +29,4 @@ module ScanBeacon
     end
 
   end
-  DefaultAdvertiser = CoreBluetoothAdvertiser
 end

--- a/lib/scan_beacon/core_bluetooth_scanner.rb
+++ b/lib/scan_beacon/core_bluetooth_scanner.rb
@@ -22,5 +22,4 @@ module ScanBeacon
     end
 
   end
-  DefaultScanner = CoreBluetoothScanner
 end


### PR DESCRIPTION
With the defaults being set in the individual files it causes constant redefined warnings if more than one of these files is loaded. The intent is for these values to be set based on the operation system. The main gem entry point already has the check and loads the appropriate scanner and advertiser classes. However, a consumer can still manually load one of the other files which will cause the warning.

This changes where the constants are defined so that they are only defined in the main gem entry point. This makes it explicit that these constants are set once based on the OS. It also frees up consumers to require non-OS classes for whatever reason they choose, without causing conflicts to the OS default constants.