### PR TITLE
On a mac, only link to IOBluetooth - fixes an issue on Mavericks

### DIFF
--- a/ext/core_bluetooth/core_bluetooth.m
+++ b/ext/core_bluetooth/core_bluetooth.m
@@ -4,7 +4,6 @@
 #include "ruby.h"
 #import <Foundation/Foundation.h>
 #import <IOBluetooth/IOBluetooth.h>
-#import <CoreBluetooth/CoreBluetooth.h>
 
 // Defining a space for information and references about the module to be stored internally
 VALUE cb_module = Qnil;

--- a/ext/core_bluetooth/extconf.rb
+++ b/ext/core_bluetooth/extconf.rb
@@ -9,7 +9,6 @@ dir_config(extension_name)
 
 if RUBY_PLATFORM =~ /darwin/
   $DLDFLAGS << " -framework Foundation"
-  $DLDFLAGS << " -framework CoreBluetooth"
   $DLDFLAGS << " -framework IOBluetooth"
 else
   # don't compile the code on non-mac platforms because


### PR DESCRIPTION
Even though we reference `CBCentralManager`, we only need to link to `IOBluetooth`.

Fixes #28