### PR TITLE
fix for macOS Sierra

### DIFF
--- a/ext/core_bluetooth/core_bluetooth.m
+++ b/ext/core_bluetooth/core_bluetooth.m
@@ -5,6 +5,11 @@
 #import <Foundation/Foundation.h>
 #import <IOBluetooth/IOBluetooth.h>
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
+// macOS Sierra requires you to import CB separately
+#import <CoreBluetooth/CoreBluetooth.h>
+#endif
+
 // Defining a space for information and references about the module to be stored internally
 VALUE cb_module = Qnil;
 


### PR DESCRIPTION
In previous versions, including `IOBluetooth` seemed to get all the `CoreBluetooth` classes as well.  That doesn't seem to work on Sierra, so we have to manually import `CoreBluetooth`.